### PR TITLE
Horizontal Pod Autoscaler

### DIFF
--- a/charts/deployment/Chart.yaml
+++ b/charts/deployment/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: A Helm chart for Kubernetes
 # name can only be lowercase. It is used in the templats.
 name: deployment
-version: 1.1.0
+version: 1.2.0

--- a/charts/deployment/templates/deployment.yaml
+++ b/charts/deployment/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
       {{- if .Values.linkerd.enabled }}
       annotations:
         linkerd.io/inject: enabled
+        config.linkerd.io/proxy-cpu-request: 100m
+        config.linkerd.io/proxy-memory-limit: 250Mi
+        config.linkerd.io/proxy-memory-request: 20Mi
       {{- end }}
     spec:
     {{- if .Values.image.pullSecrets }}
@@ -43,6 +46,20 @@ spec:
               value: "/mnt/keys"
           ports:
             - containerPort: {{ .Values.service.internalPort }}
+          resources:
+            requests:
+              cpu: {{ .Values.resources.requests.cpu }}
+              memory: {{ .Values.resources.requests.memory }}
+            {{- end }}
+            {{- if .Values.resources.limits }}
+            limits:
+              {{- if .Values.resources.limits.cpu }}
+              cpu: {{ .Values.resources.limits.cpu }}
+              {{- end }}
+              {{- if .Values.resources.limits.memory }}
+              memory: {{ .Values.resources.limits.memory }}
+              {{- end }}
+            {{- end }}
           securityContext:
             runAsUser: 1000
             runAsGroup: 3000

--- a/charts/deployment/templates/deployment.yaml
+++ b/charts/deployment/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -11,11 +11,11 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "name" . }}
+      app: {{ template "fullname" . }}
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "fullname" . }}
         release: {{ .Release.Name }}
       {{- if .Values.linkerd.enabled }}
       annotations:

--- a/charts/deployment/templates/horizontalPodAutoscaler.yaml
+++ b/charts/deployment/templates/horizontalPodAutoscaler.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "fullname" . }}
+  minReplicas: {{ .Values.autoScaling.replicas.min | default 2 }}
+  maxReplicas: {{ .Values.autoScaling.replicas.max | default 10 }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoScaling.avgCpuUtilization | default 70}}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.autoScaling.behavior.stabilizationWindowSeconds.scaleDown | default 120 }}
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.autoScaling.behavior.stabilizationWindowSeconds.scaleUp | default 0 }}
+{{- end }}

--- a/charts/deployment/templates/service.yaml
+++ b/charts/deployment/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -15,5 +15,5 @@ spec:
       protocol: TCP
       name: {{ .Values.service.name }}
   selector:
-    app: {{ template "name" . }}
+    app: {{ template "fullname" . }}
     release: {{ .Release.Name }}

--- a/charts/deployment/values.yaml
+++ b/charts/deployment/values.yaml
@@ -1,4 +1,20 @@
-replicaCount: 1
+replicaCount: 2
+
+autoScaling:
+  enabled: true
+  replicas:
+    min: 2
+    max: 10
+  avgCpuUtilization: 70
+  behavior:
+    stabilizationWindowSeconds:
+      scaleUp: 0
+      scaleDown: 120
+
+resources:
+  requests:
+    cpu: 400m
+    memory: 128Mi
 
 image:
   # Set "repository" name of your image for manual Helm install and upgrade.


### PR DESCRIPTION
* Replace name with fullname for labels and selectors

      HPA use labels to identify pods for scaling.
        
      Using only name, HPA would calculated CPU/MEM usage for all pods deployed with this chart
* Add horizontal pod autoscaler 

      add requests for all containers including containers injected by linkerd
      scaling options exposed in values.yaml
      add opt-out HPA configuration