### PR TITLE
Raise value resource request to 256Mi

### DIFF
--- a/charts/deployment/values.yaml
+++ b/charts/deployment/values.yaml
@@ -14,7 +14,7 @@ autoscaling:
 resources:
   requests:
     cpu: 50m
-    memory: 128Mi
+    memory: 256Mi
 
 image:
   # Set "repository" name of your image for manual Helm install and upgrade.


### PR DESCRIPTION
Raise deployment resource request memory to 256Mi. Most apps run around 128Mi idle and need around 200Mi with a load. Having value to low make apps prune to be rescheduled.

## Description
Changed default value in values.yaml to 256Mi

## Related Issue(s)
- N/A

## Verification
- [N/A] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
