### PR TITLE
Add optional ServiceMonitor for deployments

### DIFF
--- a/charts/deployment/Chart.yaml
+++ b/charts/deployment/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: A Helm chart for Kubernetes
 # name can only be lowercase. It is used in the templates.
 name: deployment
-version: 3.0.1
+version: 3.1.0

--- a/charts/deployment/templates/service.yaml
+++ b/charts/deployment/templates/service.yaml
@@ -14,6 +14,12 @@ spec:
       targetPort: {{ .Values.service.internalPort }}
       protocol: TCP
       name: {{ .Values.service.name }}
+{{- if .Values.metrics.enabled }}
+    - port: {{ .Values.metrics.serviceport.port }}
+      targetPort: {{ .Values.metrics.serviceport.targetPort }}
+      protocol: {{ .Values.metrics.serviceport.protocol }}
+      name: {{ .Values.metrics.serviceport.name }}
+{{- end }}
   selector:
     app: {{ template "fullname" . }}
     release: {{ .Release.Name }}

--- a/charts/deployment/templates/servicemonitor.yaml
+++ b/charts/deployment/templates/servicemonitor.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    release: {{ .Values.metrics.prometheus.instance }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+      release: {{ .Release.Name }}
+  endpoints:
+  - port: {{ .Values.metrics.serviceport.portname }}
+{{- end }}

--- a/charts/deployment/values.yaml
+++ b/charts/deployment/values.yaml
@@ -106,3 +106,14 @@ liveness:
   failureThreshold: 3
   periodSeconds: 10
   timeoutSeconds: 30
+
+metrics:
+  enabled: false
+  serviceport:
+    port: 5006
+    targetPort: 5006
+    protocol: TCP
+    portname: metrics
+  monitor:
+    instance: kube-prometheus-stack
+  


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make it easy to enable scraping of metrics from v8 applications

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
