### PR TITLE
deployment chart changes to accomodate Maskinporten integration

### DIFF
--- a/charts/deployment/templates/deployment.yaml
+++ b/charts/deployment/templates/deployment.yaml
@@ -81,13 +81,14 @@ spec:
             runAsUser: 1000
             runAsGroup: 3000
             allowPrivilegeEscalation: false
-          {{- if .Values.volumeMounts}}
           volumeMounts:
             {{- range $mount := .Values.volumeMounts}}
             - name: {{ $mount.name }}
               mountPath: {{ $mount.mountPath }}
             {{- end }}
-          {{- end }}
+            - name: app-secrets-volume
+              mountPath: /mnt/app-secrets
+              readOnly: true
           {{- if .Values.startup.enabled}}
           startupProbe:
             httpGet:
@@ -119,13 +120,16 @@ spec:
           {{- end }}
       volumes:
         {{- range $volume := .Values.volumes }}
-          - name: {{ $volume.name }}
-            {{- if $volume.persistentVolumeClaim }}
-            persistentVolumeClaim:
-              claimName: {{ $volume.persistentVolumeClaim.claimName }}
-            {{- end }}
-            {{- if $volume.secret }}
-            secret:
-              secretName: {{ $volume.secret.secretName }}
-            {{- end }}
+        - name: {{ $volume.name }}
+          {{- if $volume.persistentVolumeClaim }}
+          persistentVolumeClaim:
+            claimName: {{ $volume.persistentVolumeClaim.claimName }}
+          {{- end }}
+          {{- if $volume.secret }}
+          secret:
+            secretName: {{ $volume.secret.secretName }}
+          {{- end }}
         {{- end }}
+        - name: app-secrets-volume
+          secret:
+            secretName: {{ template "fullname" . }}-secrets

--- a/charts/deployment/templates/secret.yaml
+++ b/charts/deployment/templates/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "fullname" . }}-secrets
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+immutable: false
+data: {}


### PR DESCRIPTION
Implementing changes related to https://github.com/Altinn/app-lib-dotnet/issues/492

## Description

Current plan is to have an operator that will reconcile MaskinportenClient CRD's into a secret that is mounted in application pods.
Backend lib can then load Maskinporten-related settings needed to create Maskinporten access token. Operator will also rotate JWKs and so lib can watch for changes

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/492

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
