### PR TITLE
feat: Add IPv6 dual stack support and fix YAML formatting

### DIFF
--- a/charts/deployment/templates/service.yaml
+++ b/charts/deployment/templates/service.yaml
@@ -17,3 +17,9 @@ spec:
   selector:
     app: {{ template "fullname" . }}
     release: {{ .Release.Name }}
+{{- if .Values.ipv6.enabled }}
+  ipFamilyPolicy: PreferDualStack
+  ipFamilies:
+    - IPv4
+    - IPv6
+{{- end }}

--- a/charts/deployment/values.yaml
+++ b/charts/deployment/values.yaml
@@ -10,22 +10,23 @@ autoscaling:
     scaleUp:
       stabilizationWindowSeconds: 0
       policies:
-      - type: Pods
-        value: 1
-        periodSeconds: 15
+        - type: Pods
+          value: 1
+          periodSeconds: 15
     scaleDown:
       stabilizationWindowSeconds: 300
       policies:
-      - type: Pods
-        value: 1
-        periodSeconds: 60
+        - type: Pods
+          value: 1
+          periodSeconds: 60
 
 resources:
   requests:
     cpu: 50m
     memory: 256Mi
 
-podAnnotations: {}
+podAnnotations:
+  {}
   # Additional pod annotations (e.g. for mesh injection)
   # Enabling of linkerd in seperate value under
   # config.linkerd.io/proxy-cpu-request: 10m
@@ -49,9 +50,12 @@ service:
   externalPort: 80
   # If your application is running on another port, change only the internal port.
   internalPort: 5005
+# Enable dual stack for service
+ipv6:
+  enabled: true
 
 linkerd:
-    enabled: true
+  enabled: true
 
 ingressRoute:
   name: Will be inserted during deploy
@@ -77,7 +81,7 @@ volumeMounts:
     mountPath: "/accesstoken"
 
 volumes:
-  - name : datakeys
+  - name: datakeys
     persistentVolumeClaim:
       claimName: keys
   - name: accesstoken


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Adds conditional dual stack configuration to service template with IPv4/IPv6 support when ipv6.enabled is true.
- Also fixes indentation and spacing inconsistencies throughout values.yaml.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
