### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,4 +1,6 @@
 name: Validate Charts
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Altinn/altinn-studio-charts/security/code-scanning/9](https://github.com/Altinn/altinn-studio-charts/security/code-scanning/9)

To fix the problem, explicitly set the `permissions` block in the workflow file to the minimal required set, according to the principle of least privilege. Since the job only checks out code and runs helm lint on the repository contents, the only required permission is `contents: read`. The most robust and future-proof solution is to set `permissions: contents: read` at the workflow (top) level, just below the `name` field, making it the default for all jobs defined in this workflow. This maintains current functionality but limits unnecessary write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
