### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,6 @@
 name: Release Charts
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Altinn/altinn-studio-charts/security/code-scanning/8](https://github.com/Altinn/altinn-studio-charts/security/code-scanning/8)

To fix the problem, explicitly declare a minimal `permissions` block for the workflow/job, granting only what's required. Helm Chart Releaser uses the `contents` scope (for creating releases and uploading assets/tags), so `contents: write` is required. If only reading code or public assets, then `contents: read` would suffice, but the upload/modify actions require `write`.

Add a `permissions` block to the workflow—either at the root level (for all jobs) or at the `release` job level. A correct minimal block would be:
```yaml
permissions:
  contents: write
```
Insert this at the top level (after `name: ...`) or inside the `release` job. Root level is preferred for clarity and scalability (covers all jobs), but either option suffices here.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
