### PR TITLE
PDF generator: use europe/oslo time zone for chrome

### DIFF
--- a/charts/pdf-generator/Chart.yaml
+++ b/charts/pdf-generator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: A Helm chart for the pdf generator
 # name can only be lowercase. It is used in the templats.
 name: pdf-generator
-version: 1.7.0
+version: 1.8.0

--- a/charts/pdf-generator/values.yaml
+++ b/charts/pdf-generator/values.yaml
@@ -33,6 +33,9 @@ image:
   repository: altinncr.azurecr.io/browserless/chrome
   tag: 1-puppeteer-21.4.1
   pullPolicy: IfNotPresent
+  env:
+    - name: TZ
+      value: "Europe/Oslo"
 
 service:
   name: pdf-generator


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Sets the time zone used by chrome to `Europe/Oslo`.

When app-frontend formats dates, this happens in the browsers time zone. Currently, chrome is on UTC so we can get a mismatch in dates if a timestamp is close to midnight. Example:

![Image](https://github.com/user-attachments/assets/3516d389-71ae-45ad-b96b-48f5a329e50e)

## Related Issue(s)
- https://digdir-samarbeid.slack.com/archives/C02EJ9HKQA3/p1758030839027379

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
