### PR TITLE
feat: add POD_UID as envvar

### DIFF
--- a/charts/deployment/Chart.yaml
+++ b/charts/deployment/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: A Helm chart for Kubernetes
 # name can only be lowercase. It is used in the templates.
 name: deployment
-version: 3.8.0
+version: 3.9.0

--- a/charts/deployment/templates/deployment.yaml
+++ b/charts/deployment/templates/deployment.yaml
@@ -73,6 +73,8 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.uid
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.uid=$(POD_UID)"
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           resources:

--- a/charts/deployment/templates/deployment.yaml
+++ b/charts/deployment/templates/deployment.yaml
@@ -68,6 +68,11 @@ spec:
           {{- end }}
             - name: ALTINN_KEYS_DIRECTORY
               value: "/mnt/keys"
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.uid
           ports:
             - containerPort: {{ .Values.service.internalPort }}
           resources:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To get better metadata from k8s when moving to otel adding the pod_uid as a envvar makes it easier for applications to add the necessary metadata that otel needs to fetch the rest from k8s.

I have an example dotnet application that leverages this env var in it's otel setup here: https://github.com/tjololo/hello-dotnet/blob/main/Program.cs#L121-L134

Would it be possible to get similar logic in the app-lib?

<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
