### PR TITLE
fix: keep deployment app secret during Helm remediation

### DIFF
--- a/charts/deployment/Chart.yaml
+++ b/charts/deployment/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: A Helm chart for Kubernetes
 # name can only be lowercase. It is used in the templates.
 name: deployment
-version: 3.10.0
+version: 3.10.1

--- a/charts/deployment/templates/secret.yaml
+++ b/charts/deployment/templates/secret.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "fullname" . }}-secrets
+  annotations:
+    "helm.sh/resource-policy": keep
   labels:
     app: {{ template "fullname" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -9,4 +11,3 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 immutable: false
-data: {}


### PR DESCRIPTION
## Summary

- Add `helm.sh/resource-policy: keep` to the deployment chart app Secret.
- Stop rendering an explicit empty `data: {}` map for the app Secret.
- Bump the deployment chart version from `3.10.0` to `3.10.1`.

## Why

The deployment chart creates `<release>-deployment-secrets`, but runtime controllers later write mutable app state into that Secret:

- `maskinporten-settings.json`, including private JWKS/private key material
- `app-codes.json`, including generated callback verification codes

One example TT02 failure sequence that produced the bad state:

- `2026-05-29T00:04Z`: the app was undeployed by automated idle undeploy.
- `2026-06-03T06:42:33Z`: Flux applied `HelmRelease/default/ttd-some-app-prod` and `MaskinportenClient/default/ttd-some-app`.
- `2026-06-03T06:42:33Z-06:42:36Z`: Maskinporten reconciled immediately, but the app Secret did not exist yet, so it requeued.
- `2026-06-03T06:42:36Z`: Helm install started and created `default/ttd-some-app-deployment-secrets`; AppCodes saw the Secret create event and wrote `app-codes.json`.
- `2026-06-03T06:42:37Z-06:42:38Z`: Maskinporten retried, created the Maskinporten API client, and wrote `maskinporten-settings.json`.
- `2026-06-03T06:47:36Z`: Helm install timed out waiting for resources to become ready, in the example/reported case due a separate readiness/networking issue.
- `2026-06-03T06:47:36Z-06:47:47Z`: Flux install remediation ran Helm uninstall. Because the app Secret was a normal Helm-owned Secret, Helm deleted it, including `maskinporten-settings.json` and the private JWKS.
- `2026-06-03T06:47:47Z`: Flux retried the install and Helm recreated the app Secret empty. AppCodes restored `app-codes.json`, but Maskinporten did not immediately run because it does not watch app Secret events.
- The resulting app Secret existed with `app-codes.json` only. Apps using Maskinporten then failed because `maskinporten-settings.json` was missing from the projected runtime secrets volume.

`AppCodesSync` watches app Secret create/update events, so it restored `app-codes.json`. The Maskinporten controller does not watch app Secret events, so `maskinporten-settings.json` was not restored until a later Maskinporten reconcile. At that point the original private key material had already been lost, forcing JWKS regeneration/rotation.

Marking the Secret with `helm.sh/resource-policy: keep` prevents Helm uninstall/remediation from deleting the mutable Secret. Removing `data: {}` also avoids declaring an empty desired data map for a Secret whose contents are owned by runtime controllers.

The chart version is bumped so chart-releaser will publish the fixed deployment chart.

## Testing

<details>
<summary>Test commands and results</summary>

### Static render/lint

Command:

```bash
helm lint charts/deployment \
  --set image.repository=nginx \
  --set image.tag=stable \
  --set autoscaling.enabled=false \
  --set readiness.enabled=false \
  --set liveness.enabled=false \
  --set linkerd.enabled=false \
  --set ipv6.enabled=false \
  --set ingressRoute.name=test-route \
  --set 'ingressRoute.routes[0].match=PathPrefix(`/test`)' \
  --set 'ingressRoute.routes[0].kind=Rule' \
  --set ingressRoute.routes[0].services[0].name=test-deployment \
  --set ingressRoute.routes[0].services[0].port=80 \
  --set ingressRoute.routes[0].middlewares[0].name=hsts-header
```

Result:

```text
==> Linting charts/deployment
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

Command:

```bash
helm template test charts/deployment \
  --set image.repository=nginx \
  --set image.tag=stable \
  --set autoscaling.enabled=false \
  --set readiness.enabled=false \
  --set liveness.enabled=false \
  --set linkerd.enabled=false \
  --set ipv6.enabled=false \
  --set ingressRoute.name=test-route \
  --set 'ingressRoute.routes[0].match=PathPrefix(`/test`)' \
  --set 'ingressRoute.routes[0].kind=Rule' \
  --set ingressRoute.routes[0].services[0].name=test-deployment \
  --set ingressRoute.routes[0].services[0].port=80 \
  --set ingressRoute.routes[0].middlewares[0].name=hsts-header
```

Rendered Secret:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: test-deployment-secrets
  annotations:
    "helm.sh/resource-policy": keep
  labels:
    app: test-deployment
    chart: deployment-3.10.1
    release: test
    heritage: Helm
type: Opaque
immutable: false
```

Verified:

- Secret has `helm.sh/resource-policy: keep`.
- Secret is still `type: Opaque`.
- Secret has expected name and labels.
- Secret render has no `data:` field.
- Render output does not include `maskinporten`, `app-codes`, private-key-like content, `BEGIN`, or JWKS payloads.

### Helm/kind lifecycle

Created a kind cluster and installed the old chart from `main` first to cover the production migration path.

Commands included:

```bash
kind create cluster --name chart-secret-keep
git worktree add /data/home/code/altinn-studio-charts-main main
helm install chartkeep /data/home/code/altinn-studio-charts-main/charts/deployment ...
kubectl patch secret chartkeep-deployment-secrets --type merge -p '{"stringData":{"maskinporten-settings.json":"{\"dummy\":\"maskin\"}","app-codes.json":"{\"dummy\":\"codes\"}"}}'
helm upgrade chartkeep charts/deployment ...
helm upgrade chartkeep charts/deployment ...
helm uninstall chartkeep
helm install chartkeep charts/deployment ...
```

Results:

- Old chart `3.10.0` created `chartkeep-deployment-secrets` as an empty Opaque Secret with no keep annotation.
- After patching dummy data, upgrade from old chart to fixed chart `3.10.1` preserved both dummy keys.
- Fixed chart added `helm.sh/resource-policy: keep`.
- A second fixed-chart upgrade also preserved both dummy keys.
- `helm uninstall chartkeep` reported:

```text
These resources were kept due to the resource policy:
[Secret] chartkeep-deployment-secrets
```

- The Secret still existed after uninstall and retained both dummy keys.
- Reinstalling the same release name succeeded and retained both dummy keys.

Caveat: same release name/same namespace reinstall works because Helm ownership metadata still matches. A different release name or namespace would not adopt the kept Secret.

Cleaned up:

```bash
kubectl delete secret chartkeep-deployment-secrets
kind delete cluster --name chart-secret-keep
git worktree remove /data/home/code/altinn-studio-charts-main
```

### Flux remediation reproduction

Created a second kind cluster with Flux `source-controller` and `helm-controller`, served local chart packages for both versions, and reproduced the failure mode.

Setup included:

```bash
kind create cluster --name chart-secret-repro
flux install --components=source-controller,helm-controller
helm package /data/home/code/altinn-studio-charts-main/charts/deployment -d /tmp/altinn-chartrepo
helm package /data/home/code/altinn-studio-charts/charts/deployment -d /tmp/altinn-chartrepo
helm repo index /tmp/altinn-chartrepo
python3 -m http.server 18080 --bind 0.0.0.0
```

Old chart reproduction:

- Flux installed chart `deployment@3.10.0`.
- Patched dummy `maskinporten-settings.json` and `app-codes.json` into `fluxrepro-deployment-secrets`.
- Forced an invalid upgrade with `service.externalPort: "bad-port"` and `upgrade.remediation.strategy: uninstall`.
- Flux events showed:
  - `UpgradeFailed`
  - `UninstallSucceeded`
  - fresh `InstallFailed`
- After remediation, `fluxrepro-deployment-secrets` existed again but both dummy keys were gone.
- The recreated Secret had no `helm.sh/resource-policy` annotation.

Fixed chart validation:

- Upgraded the Flux release to chart `deployment@3.10.1`.
- Confirmed the Secret had:
  - `annotation=keep`
  - `chart=deployment-3.10.1`
- Patched dummy `maskinporten-settings.json` and `app-codes.json` again.
- Repeated the same invalid Flux upgrade/remediation path.
- Flux again showed uninstall remediation, but the Secret retained both dummy keys:

```text
annotation=keep
chart=deployment-3.10.1
maskin=eyJkdW1teSI6Im1hc2tpbi1maXhlZCJ9
codes=eyJkdW1teSI6ImNvZGVzLWZpeGVkIn0=
```

- Restored valid values and reconciled successfully. The Secret still retained both dummy keys.

Cleaned up:

```bash
kind delete cluster --name chart-secret-repro
rm -rf /tmp/altinn-chartrepo
git worktree remove /data/home/code/altinn-studio-charts-main
```

</details>

## Notes

This prevents accidental data loss during idle undeploy/failed install remediation. Permanent app decommissioning should use an explicit cleanup path for retained runtime state instead of relying on Helm uninstall side effects.

Longer term, we should add a conservative cleanup mechanism for apps that are permanently decommissioned. That cleanup should be driven by an explicit lifecycle signal, not ordinary idle undeploy/remediation, and should remove retained runtime state such as deployment Secrets only after an appropriate retention/grace period.
