### PR TITLE
feat: Add Linkerd integration and name ports consistently

### DIFF
--- a/charts/deployment/Chart.yaml
+++ b/charts/deployment/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: A Helm chart for Kubernetes
 # name can only be lowercase. It is used in the templates.
 name: deployment
-version: 3.10.1
+version: 3.11.0

--- a/charts/deployment/templates/deployment.yaml
+++ b/charts/deployment/templates/deployment.yaml
@@ -81,6 +81,7 @@ spec:
           {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
+              name: http
           resources:
             requests:
               cpu: {{ .Values.resources.requests.cpu }}

--- a/charts/deployment/templates/linkerd.yaml
+++ b/charts/deployment/templates/linkerd.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.linkerd.enabled }}
+---
+apiVersion: policy.linkerd.io/v1beta3
+kind: Server
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+  port: http
+  proxyProtocol: HTTP/1
+  accessPolicy: all-unauthenticated
+---
+apiVersion: policy.linkerd.io/v1beta1
+kind: ServerAuthorization
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  server:
+    name: {{ template "fullname" . }}
+  client:
+    meshTLS:
+      identities:
+        - "*"
+{{- end }}

--- a/charts/deployment/templates/service.yaml
+++ b/charts/deployment/templates/service.yaml
@@ -13,7 +13,7 @@ spec:
     - port: {{ .Values.service.externalPort }}
       targetPort: {{ .Values.service.internalPort }}
       protocol: TCP
-      name: {{ .Values.service.name }}
+      name: http
   selector:
     app: {{ template "fullname" . }}
     release: {{ .Release.Name }}

--- a/charts/deployment/values.yaml
+++ b/charts/deployment/values.yaml
@@ -56,7 +56,6 @@ image:
   # - name: myRegistryKeySecretName
 
 service:
-  name: deployment
   type: ClusterIP
   externalPort: 80
   # If your application is running on another port, change only the internal port.


### PR DESCRIPTION
- Bump chart version to 3.11.0
- Add Linkerd Server and ServerAuthorization resources
- Standardize port naming to "http" across deployment and service definitions
- Remove redundant service name configuration

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
