### PR TITLE
fix: coordinate app shutdown with Linkerd

### DIFF
--- a/charts/deployment/Chart.yaml
+++ b/charts/deployment/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 description: A Helm chart for Kubernetes
 # name can only be lowercase. It is used in the templates.
 name: deployment
-version: 3.11.0
+version: 3.12.0

--- a/charts/deployment/templates/deployment.yaml
+++ b/charts/deployment/templates/deployment.yaml
@@ -27,17 +27,18 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- if .Values.linkerd.enabled }}
-        {{- /* Reserve the end of the pod budget for Linkerd to drain its regular sidecar. */}}
-        {{- $proxyShutdownGracePeriodSeconds := 5 }}
+        {{- $endpointDrainDelaySeconds := 5 }}
+        {{- $hardShutdownBufferSeconds := 5 }}
         {{- $terminationGracePeriodSeconds := int .Values.terminationGracePeriodSeconds }}
-        {{- if le $terminationGracePeriodSeconds $proxyShutdownGracePeriodSeconds }}
-        {{- fail (printf "terminationGracePeriodSeconds must be greater than %d when Linkerd is enabled" $proxyShutdownGracePeriodSeconds) }}
+        {{- $reservedSeconds := add $endpointDrainDelaySeconds $hardShutdownBufferSeconds }}
+        {{- if le $terminationGracePeriodSeconds $reservedSeconds }}
+        {{- fail (printf "terminationGracePeriodSeconds must be greater than %d when Linkerd is enabled" $reservedSeconds) }}
         {{- end }}
         linkerd.io/inject: enabled
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         config.linkerd.io/skip-outbound-ports: "443"
-        config.alpha.linkerd.io/proxy-wait-before-exit-seconds: {{ sub $terminationGracePeriodSeconds $proxyShutdownGracePeriodSeconds | quote }}
-        config.linkerd.io/shutdown-grace-period: {{ printf "%ds" $proxyShutdownGracePeriodSeconds | quote }}
+        config.alpha.linkerd.io/proxy-wait-before-exit-seconds: {{ $endpointDrainDelaySeconds | quote }}
+        config.linkerd.io/shutdown-grace-period: {{ sub $terminationGracePeriodSeconds $reservedSeconds | printf "%ds" | quote }}
         {{- end }}
     spec:
     {{- if .Values.image.pullSecrets }}

--- a/charts/deployment/templates/deployment.yaml
+++ b/charts/deployment/templates/deployment.yaml
@@ -30,6 +30,12 @@ spec:
         linkerd.io/inject: enabled
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         config.linkerd.io/skip-outbound-ports: "443"
+        {{- with .Values.linkerd.waitBeforeExitSeconds }}
+        config.alpha.linkerd.io/proxy-wait-before-exit-seconds: {{ . | quote }}
+        {{- end }}
+        {{- with .Values.linkerd.shutdownGracePeriod }}
+        config.linkerd.io/shutdown-grace-period: {{ . | quote }}
+        {{- end }}
         {{- end }}
     spec:
     {{- if .Values.image.pullSecrets }}

--- a/charts/deployment/templates/deployment.yaml
+++ b/charts/deployment/templates/deployment.yaml
@@ -27,15 +27,17 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- if .Values.linkerd.enabled }}
+        {{- /* Reserve the end of the pod budget for Linkerd to drain its regular sidecar. */}}
+        {{- $proxyShutdownGracePeriodSeconds := 5 }}
+        {{- $terminationGracePeriodSeconds := int .Values.terminationGracePeriodSeconds }}
+        {{- if le $terminationGracePeriodSeconds $proxyShutdownGracePeriodSeconds }}
+        {{- fail (printf "terminationGracePeriodSeconds must be greater than %d when Linkerd is enabled" $proxyShutdownGracePeriodSeconds) }}
+        {{- end }}
         linkerd.io/inject: enabled
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         config.linkerd.io/skip-outbound-ports: "443"
-        {{- with .Values.linkerd.waitBeforeExitSeconds }}
-        config.alpha.linkerd.io/proxy-wait-before-exit-seconds: {{ . | quote }}
-        {{- end }}
-        {{- with .Values.linkerd.shutdownGracePeriod }}
-        config.linkerd.io/shutdown-grace-period: {{ . | quote }}
-        {{- end }}
+        config.alpha.linkerd.io/proxy-wait-before-exit-seconds: {{ sub $terminationGracePeriodSeconds $proxyShutdownGracePeriodSeconds | quote }}
+        config.linkerd.io/shutdown-grace-period: {{ printf "%ds" $proxyShutdownGracePeriodSeconds | quote }}
         {{- end }}
     spec:
     {{- if .Values.image.pullSecrets }}

--- a/charts/deployment/values.yaml
+++ b/charts/deployment/values.yaml
@@ -66,6 +66,12 @@ ipv6:
 
 linkerd:
   enabled: true
+  # Linkerd 2026.4.2 uses regular sidecars by default. Keep the proxy available for the app's
+  # 5-second endpoint drain delay plus 20-second application shutdown timeout.
+  # Set to 0 when the control plane injects Kubernetes native sidecars.
+  waitBeforeExitSeconds: 25
+  # Leave the final 5 seconds of the pod's 30-second termination budget for proxy draining.
+  shutdownGracePeriod: 5s
 
 ingressRoute:
   name: Will be inserted during deploy

--- a/charts/deployment/values.yaml
+++ b/charts/deployment/values.yaml
@@ -66,12 +66,6 @@ ipv6:
 
 linkerd:
   enabled: true
-  # Linkerd 2026.4.2 uses regular sidecars by default. Keep the proxy available for the app's
-  # 5-second endpoint drain delay plus 20-second application shutdown timeout.
-  # Set to 0 when the control plane injects Kubernetes native sidecars.
-  waitBeforeExitSeconds: 25
-  # Leave the final 5 seconds of the pod's 30-second termination budget for proxy draining.
-  shutdownGracePeriod: 5s
 
 ingressRoute:
   name: Will be inserted during deploy


### PR DESCRIPTION
## Description

Coordinates Altinn app shutdown with Linkerd for the currently deployed configuration: Linkerd 2026.4.2 with regular sidecars (`proxy.nativeSidecar: false`).

The app backend delays shutdown for 5 seconds while Kubernetes endpoint changes propagate, then allows up to 20 seconds for ASP.NET Core to drain requests. The chart mirrors those phases in Linkerd: a 5-second proxy pre-stop wait followed by a 20-second proxy connection-drain period, leaving the final 5 seconds of the existing 30-second pod termination budget as a hard-shutdown buffer.

The Linkerd shutdown period is derived from `terminationGracePeriodSeconds` after subtracting the fixed 5-second endpoint delay and 5-second hard-shutdown buffer. Invalid budgets of 10 seconds or less fail during Helm rendering.

Related to Altinn/altinn-studio#19804 and Altinn/altinn-studio#20003.

## Verification

- `helm lint` passed for every chart in the repository (existing template warnings only)
- Default render confirmed: 30-second pod budget, 5-second Linkerd wait, 20-second Linkerd shutdown grace
- Custom render confirmed: 45-second pod budget, 5-second Linkerd wait, 35-second Linkerd shutdown grace
- Invalid budgets fail during Helm rendering
